### PR TITLE
Img loading feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,3 @@ Restore support for Python 3.6
 ------------------
 
 Initial release as namespace plugin.
-

--- a/README.md
+++ b/README.md
@@ -49,7 +49,14 @@ appropriate Pelican setting:
 To insert a sized and labeled image in your document, enable the
 `img` tag and use the following:
 
-    {% img [class name(s)] path/to/image [width [height]] [title text | "title text" ["alt text"]] %}
+    {% img [class name(s)] path/to/image [lazy | eager] [width [height]] [title text | "title text" ["alt text"]] %}
+
+The configuration variable `IMG_DEFAULT_LOADING` can change the default beahavior
+of the plugin. `lazy` setting takes precendence over the default `eager`.
+If `lazy` is set, all the images will receive the attribute. This is not the case
+with `eager` because it's the default behavior of browsers when faced with an image.
+Explicit parameters specified in liquid-tags `img` will always take precedence
+and will always be translated into attributes.
 
 ### Base64 Image (Inline Image) Tag
 
@@ -58,7 +65,7 @@ To insert a sized and labeled image in your document, enable the
 To use it:
 
 1. Enable `b64img`
-1. Insert a tag as follows: `{% b64img [class name(s)] path/to/image [width [height]] [title text | "title text" ["alt text"]] %}`
+2. Insert a tag as follows: `{% b64img [class name(s)] path/to/image [width [height]] [title text | "title text" ["alt text"]] %}`
 
 Images are encoded at generation time, so you can use any local path (just be sure that the image will remain in the same location for subsequent site generations).
 

--- a/pelican/plugins/liquid_tags/audio.py
+++ b/pelican/plugins/liquid_tags/audio.py
@@ -52,7 +52,7 @@ def create_html(markup):
             base, ext = os.path.splitext(audio_file)
 
             if ext not in AUDIO_TYPEDICT:
-                raise ValueError("Unrecognized audio extension: " "{0}".format(ext))
+                raise ValueError("Unrecognized audio extension: " "{}".format(ext))
 
             # add audio source
             audio_out += '<source src="{}" type="{}">'.format(
@@ -65,7 +65,7 @@ def create_html(markup):
 
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     return audio_out

--- a/pelican/plugins/liquid_tags/giphy.py
+++ b/pelican/plugins/liquid_tags/giphy.py
@@ -35,7 +35,7 @@ GIPHY = re.compile(r"""(?P<gif_id>[\S+]+)(?:\s+(['"]{0,1})(?P<alt>.+)(\\2))?""")
 
 def get_gif(api_key, gif_id):
     """Returns dict with gif informations from the API."""
-    url = "http://api.giphy.com/v1/gifs/{}?api_key={}".format(gif_id, api_key)
+    url = f"http://api.giphy.com/v1/gifs/{gif_id}?api_key={api_key}"
     r = urlopen(url)
 
     return json.loads(r.read().decode("utf-8"))
@@ -64,13 +64,11 @@ def main(api_key, markup):
     attrs = None
 
     if match:
-        attrs = dict(
-            [
-                (key, value.strip())
+        attrs = {
+                key: value.strip()
                 for (key, value) in match.groupdict().items()
                 if value
-            ]
-        )
+        }
 
     else:
         raise ValueError(

--- a/pelican/plugins/liquid_tags/gram.py
+++ b/pelican/plugins/liquid_tags/gram.py
@@ -67,12 +67,12 @@ def gram(preprocessor, tag, markup):
     # Parse the markup string
     match = ReGram.search(markup)
     if match:
-        attrs = dict(
-            [(key, val.strip()) for (key, val) in match.groupdict().items() if val]
-        )
+        attrs = {
+            key: val.strip() for (key, val) in match.groupdict().items() if val
+        }
     else:
         raise ValueError(
-            "Error processing input. " "Expected syntax: {0}".format(SYNTAX)
+            "Error processing input. " "Expected syntax: {}".format(SYNTAX)
         )
 
     # Construct URI
@@ -82,7 +82,7 @@ def gram(preprocessor, tag, markup):
     del attrs["shortcode"]
 
     if "size" in attrs:
-        size = "?size={0}".format(attrs["size"])
+        size = "?size={}".format(attrs["size"])
         url = url + size
         del attrs["size"]
 
@@ -104,9 +104,9 @@ def gram(preprocessor, tag, markup):
     # print('updated dict: '+repr(attrs))
 
     # Return the formatted text
-    return '<img src="{0}"{1}>'.format(
+    return '<img src="{}"{}>'.format(
         gram_url,
-        " ".join(' {0}="{1}"'.format(key, val) for (key, val) in attrs.items()),
+        " ".join(f' {key}="{val}"' for (key, val) in attrs.items()),
     )
 
 

--- a/pelican/plugins/liquid_tags/img.py
+++ b/pelican/plugins/liquid_tags/img.py
@@ -60,11 +60,7 @@ def img(preprocessor, tag, markup):
     # Parse the markup string
     match = ReImg.search(markup)
     if match:
-        attrs = {
-            key: val.strip()
-            for key, val in match.groupdict().items()
-            if val
-        }
+        attrs = {key: val.strip() for key, val in match.groupdict().items() if val}
     else:
         raise ValueError(
             "Error processing input. " "Expected syntax: {0}".format(SYNTAX)

--- a/pelican/plugins/liquid_tags/img.py
+++ b/pelican/plugins/liquid_tags/img.py
@@ -63,7 +63,7 @@ def img(preprocessor, tag, markup):
         attrs = {key: val.strip() for key, val in match.groupdict().items() if val}
     else:
         raise ValueError(
-            "Error processing input. " "Expected syntax: {0}".format(SYNTAX)
+            "Error processing input. " "Expected syntax: {}".format(SYNTAX)
         )
 
     # If loading setting is modified but not at the image scale
@@ -81,8 +81,8 @@ def img(preprocessor, tag, markup):
             attrs["alt"] = attrs["title"]
 
     # Return the formatted text
-    return "<img {0}>".format(
-        " ".join('{0}="{1}"'.format(*item) for item in attrs.items())
+    return "<img {}>".format(
+        " ".join('{}="{}"'.format(*item) for item in attrs.items())
     )
 
 

--- a/pelican/plugins/liquid_tags/img.py
+++ b/pelican/plugins/liquid_tags/img.py
@@ -6,11 +6,11 @@ based on the octopress image tag [1]_
 
 Syntax
 ------
-{% img [class name(s)] [http[s]:/]/path/to/image [width [height]] [title text | "title text" ["alt text"]] %}
+{% img [class name(s)] [http[s]:/]/path/to/image [lazy | eager] [width [height]] [title text | "title text" ["alt text"]] %}
 
 Examples
 --------
-{% img /images/ninja.png Ninja Attack! %}
+{% img /images/ninja.png %}
 {% img left half http://site.com/images/ninja.png Ninja Attack! %}
 {% img left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture" %}
 
@@ -28,11 +28,11 @@ import six
 
 from .mdx_liquid_tags import LiquidTags
 
-SYNTAX = '{% img [class name(s)] [http[s]:/]/path/to/image [width [height]] [title text | "title text" ["alt text"]] %}'
+SYNTAX = '{% img [class name(s)] [http[s]:/]/path/to/image [lazy | eager] [width [height]] [title text | "title text" ["alt text"]] %}'
 
 # Regular expression to match the entire syntax
 ReImg = re.compile(
-    r"""(?P<class>\S.*\s+)?(?P<src>(?:https?:\/\/|\/|\S+\/)\S+)(?:\s+(?P<width>\d+))?(?:\s+(?P<height>\d+))?(?P<title>\s+.+)?"""
+    r"""(?P<class>\S.*\s+)?(?P<src>(?:https?:\/\/|\/|\S+\/)\S+)(?:\s+(?P<loading>lazy|eager))?(?:\s+(?P<width>\d+))?(?:\s+(?P<height>\d+))?(?P<title>\s+.+)?"""
 )
 
 # Regular expression to split the title and alt text
@@ -59,6 +59,12 @@ def img(preprocessor, tag, markup):
         raise ValueError(
             "Error processing input. " "Expected syntax: {0}".format(SYNTAX)
         )
+
+    # If loading setting is modified but not at the image scale
+    # If so, apply the global setting
+    loading = preprocessor.configs.getConfig("IMG_DEFAULT_LOADING")
+    if "loading" not in attrs and loading != "eager":
+        attrs["loading"] = loading
 
     # Check if alt text is present -- if so, split it from title
     if "title" in attrs:

--- a/pelican/plugins/liquid_tags/img.py
+++ b/pelican/plugins/liquid_tags/img.py
@@ -8,10 +8,22 @@ Syntax
 ------
 {% img [class name(s)] [http[s]:/]/path/to/image [lazy | eager] [width [height]] [title text | "title text" ["alt text"]] %}
 
+Configuration
+-------------
+
+The configuration variable `IMG_DEFAULT_LOADING` can change the default beahavior
+of the plugin. `lazy` setting takes precendence over the default `eager`.
+If `lazy` is set, all the images will receive the attribute. This is not the case
+with `eager` because it's the default behavior of browsers when faced with an image.
+Explicit parameters specified in liquid-tags `img` will always take precedence
+and will always be translated into attributes.
+
 Examples
 --------
 {% img /images/ninja.png %}
 {% img left half http://site.com/images/ninja.png Ninja Attack! %}
+{% img left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture" %}
+{% img left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture" %}
 {% img left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture" %}
 
 Output
@@ -19,6 +31,8 @@ Output
 <img src="/images/ninja.png">
 <img class="left half" src="http://site.com/images/ninja.png" title="Ninja Attack!" alt="Ninja Attack!">
 <img class="left half" src="http://site.com/images/ninja.png" width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">
+<img class="left half" src="http://site.com/images/ninja.png" loading="eager" width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">
+<img class="left half" src="http://site.com/images/ninja.png" width="150" height="150" title="Ninja Attack!" loading="lazy" alt="Ninja in attack posture">
 
 [1] https://github.com/imathis/octopress/blob/master/plugins/image_tag.rb
 """

--- a/pelican/plugins/liquid_tags/img.py
+++ b/pelican/plugins/liquid_tags/img.py
@@ -24,8 +24,6 @@ Output
 """
 import re
 
-import six
-
 from .mdx_liquid_tags import LiquidTags
 
 SYNTAX = '{% img [class name(s)] [http[s]:/]/path/to/image [lazy | eager] [width [height]] [title text | "title text" ["alt text"]] %}'
@@ -48,13 +46,11 @@ def img(preprocessor, tag, markup):
     # Parse the markup string
     match = ReImg.search(markup)
     if match:
-        attrs = dict(
-            [
-                (key, val.strip())
-                for (key, val) in six.iteritems(match.groupdict())
-                if val
-            ]
-        )
+        attrs = {
+            key: val.strip()
+            for key, val in match.groupdict().items()
+            if val
+        }
     else:
         raise ValueError(
             "Error processing input. " "Expected syntax: {0}".format(SYNTAX)
@@ -76,7 +72,7 @@ def img(preprocessor, tag, markup):
 
     # Return the formatted text
     return "<img {0}>".format(
-        " ".join('{0}="{1}"'.format(key, val) for (key, val) in six.iteritems(attrs))
+        " ".join('{0}="{1}"'.format(*item) for item in attrs.items())
     )
 
 

--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -70,12 +70,12 @@ class LiquidTags(markdown.Extension):
             # Needed for markdown versions >= 2.5
             for key, value in LT_CONFIG.items():
                 self.config[key] = [value, LT_HELP[key]]
-            super(LiquidTags, self).__init__(**config)
+            super().__init__(**config)
         except AttributeError:
             # Markdown versions < 2.5
             for key, value in LT_CONFIG.items():
                 config[key] = [config[key], LT_HELP[key]]
-            super(LiquidTags, self).__init__(config)
+            super().__init__(config)
 
     @classmethod
     def register(cls, tag):

--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -23,12 +23,14 @@ LT_CONFIG = {
     "NOTEBOOK_DIR": "notebooks",
     "FLICKR_API_KEY": "flickr",
     "GIPHY_API_KEY": "giphy",
+    "IMG_DEFAULT_LOADING": "eager",
 }
 LT_HELP = {
     "CODE_DIR": "Code directory for include_code subplugin",
     "NOTEBOOK_DIR": "Notebook directory for notebook subplugin",
     "FLICKR_API_KEY": "Flickr key for accessing the API",
     "GIPHY_API_KEY": "Giphy key for accessing the API",
+    "IMG_DEFAULT_LOADING": "The default loading method of images (eager or lazy)",
 }
 
 

--- a/pelican/plugins/liquid_tags/notebook.py
+++ b/pelican/plugins/liquid_tags/notebook.py
@@ -49,7 +49,6 @@ still be some conflicts.
 """
 from copy import deepcopy
 from functools import partial
-from io import open
 import os
 import re
 import warnings
@@ -219,7 +218,7 @@ class SliceIndex(Integer):
         if value is None:
             return value
         else:
-            return super(SliceIndex, self).validate(obj, value)
+            return super().validate(obj, value)
 
 
 class SubCell(Preprocessor):
@@ -275,7 +274,7 @@ def notebook(preprocessor, tag, markup):
         language = argdict["language"]
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     if start:
@@ -296,7 +295,7 @@ def notebook(preprocessor, tag, markup):
     )
 
     if not os.path.exists(nb_path):
-        raise ValueError("File {0} could not be found".format(nb_path))
+        raise ValueError(f"File {nb_path} could not be found")
 
     # Create the custom notebook converter
     c = Config(

--- a/pelican/plugins/liquid_tags/soundcloud.py
+++ b/pelican/plugins/liquid_tags/soundcloud.py
@@ -46,7 +46,7 @@ SOUNDCLOUD_API_URL = "https://soundcloud.com/oembed"
 
 def get_widget(track_url):
     r = urlopen(
-        SOUNDCLOUD_API_URL, data="format=json&url={}".format(track_url).encode("utf-8")
+        SOUNDCLOUD_API_URL, data=f"format=json&url={track_url}".encode("utf-8")
     )
 
     return json.loads(r.read().decode("utf-8"))["html"]

--- a/pelican/plugins/liquid_tags/speakerdeck.py
+++ b/pelican/plugins/liquid_tags/speakerdeck.py
@@ -47,7 +47,7 @@ data-ratio="{ratio}" src="//speakerdeck.com/assets/embed.js"></script>
             id=id, ratio=ratio
         )
     else:
-        raise ValueError("Error processing input, expected syntax: {0}".format(SYNTAX))
+        raise ValueError(f"Error processing input, expected syntax: {SYNTAX}")
     return speakerdeck_out
 
 

--- a/pelican/plugins/liquid_tags/spotify.py
+++ b/pelican/plugins/liquid_tags/spotify.py
@@ -48,7 +48,7 @@ def spotify(preprocessor, tag, markup):
         ).strip()
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     return spotify_out

--- a/pelican/plugins/liquid_tags/test_data/pelicanconf.py
+++ b/pelican/plugins/liquid_tags/test_data/pelicanconf.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*- #
-from __future__ import unicode_literals
 
 AUTHOR = "The Tester"
 SITENAME = "Testing site"

--- a/pelican/plugins/liquid_tags/test_flickr.py
+++ b/pelican/plugins/liquid_tags/test_flickr.py
@@ -6,7 +6,7 @@ import unittest
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 import pytest
 

--- a/pelican/plugins/liquid_tags/test_generation.py
+++ b/pelican/plugins/liquid_tags/test_generation.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 # import filecmp
 import os
 from shutil import rmtree

--- a/pelican/plugins/liquid_tags/test_generic.py
+++ b/pelican/plugins/liquid_tags/test_generic.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 # import filecmp
 import os
 from shutil import rmtree

--- a/pelican/plugins/liquid_tags/test_giphy.py
+++ b/pelican/plugins/liquid_tags/test_giphy.py
@@ -5,7 +5,7 @@ import unittest
 try:
     from unittest.mock import patch
 except ImportError:
-    from mock import patch
+    from unittest.mock import patch
 
 import pytest
 

--- a/pelican/plugins/liquid_tags/test_img.py
+++ b/pelican/plugins/liquid_tags/test_img.py
@@ -10,11 +10,14 @@ from .img import img
 
 class MockPreprocessor:
     """Mocking _LiquidTagsPreprocessor class used for its `configs` attr"""
+
     def __init__(self, configs):
         self.configs = configs
 
+
 class MockConfigs:
     """Mocking Configs class that store the plugin settings in a dict"""
+
     def __init__(self, configs):
         self.configs = configs
 
@@ -23,14 +26,15 @@ class MockConfigs:
 
 
 class TestImgTag(unittest.TestCase):
-
     def setUp(self):
-        self.preprocessor = MockPreprocessor(MockConfigs({"IMG_DEFAULT_LOADING": "eager"}))
+        self.preprocessor = MockPreprocessor(
+            MockConfigs({"IMG_DEFAULT_LOADING": "eager"})
+        )
         self.tag = "img"
 
     def test_normal_relative_path(self):
         markup = "/images/ninja.png"
-        expected = ('<img src="/images/ninja.png">')
+        expected = '<img src="/images/ninja.png">'
         actual = img(self.preprocessor, self.tag, markup)
         self.assertIn(expected, actual)
 
@@ -44,9 +48,7 @@ class TestImgTag(unittest.TestCase):
         self.assertIn(expected, actual)
 
     def test_classnames_sizes_title_alt(self):
-        markup = (
-            'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
-        )
+        markup = 'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
         expected = (
             '<img class="left half" src="http://site.com/images/ninja.png" '
             'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
@@ -55,9 +57,7 @@ class TestImgTag(unittest.TestCase):
         self.assertIn(expected, actual)
 
     def test_classnames_sizes_title_alt_loading(self):
-        markup = (
-            'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
-        )
+        markup = 'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
         expected = (
             '<img class="left half" src="http://site.com/images/ninja.png" loading="eager" '
             'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
@@ -67,9 +67,7 @@ class TestImgTag(unittest.TestCase):
 
     def test_classnames_sizes_title_alt_default_loading(self):
         self.preprocessor.configs.configs["IMG_DEFAULT_LOADING"] = "lazy"
-        markup = (
-            'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
-        )
+        markup = 'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
         # Loading key is not specified but the default settings takes precedence
         expected = (
             '<img class="left half" src="http://site.com/images/ninja.png" '
@@ -78,15 +76,14 @@ class TestImgTag(unittest.TestCase):
         actual = img(self.preprocessor, self.tag, markup)
         self.assertIn(expected, actual)
 
-        markup = (
-            'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
-        )
+        markup = 'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
         expected = (
             '<img class="left half" src="http://site.com/images/ninja.png" loading="eager" '
             'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
         )
         actual = img(self.preprocessor, self.tag, markup)
         self.assertIn(expected, actual)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pelican/plugins/liquid_tags/test_img.py
+++ b/pelican/plugins/liquid_tags/test_img.py
@@ -1,0 +1,92 @@
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    from mock import patch
+
+from .img import img
+
+
+class MockPreprocessor:
+    """Mocking _LiquidTagsPreprocessor class used for its `configs` attr"""
+    def __init__(self, configs):
+        self.configs = configs
+
+class MockConfigs:
+    """Mocking Configs class that store the plugin settings in a dict"""
+    def __init__(self, configs):
+        self.configs = configs
+
+    def getConfig(self, key):
+        return self.configs.get(key)
+
+
+class TestImgTag(unittest.TestCase):
+
+    def setUp(self):
+        self.preprocessor = MockPreprocessor(MockConfigs({"IMG_DEFAULT_LOADING": "eager"}))
+        self.tag = "img"
+
+    def test_normal_relative_path(self):
+        markup = "/images/ninja.png"
+        expected = ('<img src="/images/ninja.png">')
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+    def test_classnames_title_noalt(self):
+        markup = "left half http://site.com/images/ninja.png Ninja Attack!"
+        expected = (
+            '<img class="left half" src="http://site.com/images/ninja.png" '
+            'title="Ninja Attack!" alt="Ninja Attack!">'
+        )
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+    def test_classnames_sizes_title_alt(self):
+        markup = (
+            'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
+        )
+        expected = (
+            '<img class="left half" src="http://site.com/images/ninja.png" '
+            'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
+        )
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+    def test_classnames_sizes_title_alt_loading(self):
+        markup = (
+            'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
+        )
+        expected = (
+            '<img class="left half" src="http://site.com/images/ninja.png" loading="eager" '
+            'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
+        )
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+    def test_classnames_sizes_title_alt_default_loading(self):
+        self.preprocessor.configs.configs["IMG_DEFAULT_LOADING"] = "lazy"
+        markup = (
+            'left half http://site.com/images/ninja.png 150 150 "Ninja Attack!" "Ninja in attack posture"'
+        )
+        # Loading key is not specified but the default settings takes precedence
+        expected = (
+            '<img class="left half" src="http://site.com/images/ninja.png" '
+            'width="150" height="150" title="Ninja Attack!" loading="lazy" alt="Ninja in attack posture">'
+        )
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+        markup = (
+            'left half http://site.com/images/ninja.png eager 150 150 "Ninja Attack!" "Ninja in attack posture"'
+        )
+        expected = (
+            '<img class="left half" src="http://site.com/images/ninja.png" loading="eager" '
+            'width="150" height="150" title="Ninja Attack!" alt="Ninja in attack posture">'
+        )
+        actual = img(self.preprocessor, self.tag, markup)
+        self.assertIn(expected, actual)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pelican/plugins/liquid_tags/test_img.py
+++ b/pelican/plugins/liquid_tags/test_img.py
@@ -1,10 +1,5 @@
 import unittest
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
-
 from .img import img
 
 

--- a/pelican/plugins/liquid_tags/test_notebook.py
+++ b/pelican/plugins/liquid_tags/test_notebook.py
@@ -31,68 +31,68 @@ class TestNotebookTagRegex(unittest.TestCase):
         return None
 
     def test_basic_notebook_tag(self):
-        markup = u"path/to/thing.ipynb"
+        markup = "path/to/thing.ipynb"
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
+        self.assertEqual(src, "path/to/thing.ipynb")
         self.assertIsNone(start)
         self.assertIsNone(end)
         self.assertIsNone(language)
 
     def test_basic_notebook_tag_insensitive_to_whitespace(self):
-        markup = u"   path/to/thing.ipynb "
+        markup = "   path/to/thing.ipynb "
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
+        self.assertEqual(src, "path/to/thing.ipynb")
         self.assertIsNone(start)
         self.assertIsNone(end)
         self.assertIsNone(language)
 
     def test_notebook_tag_with_cells(self):
-        markup = u"path/to/thing.ipynb cells[1:5]"
+        markup = "path/to/thing.ipynb cells[1:5]"
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
-        self.assertEqual(start, u"1")
-        self.assertEqual(end, u"5")
+        self.assertEqual(src, "path/to/thing.ipynb")
+        self.assertEqual(start, "1")
+        self.assertEqual(end, "5")
         self.assertIsNone(language)
 
     def test_notebook_tag_with_alphanumeric_language(self):
-        markup = u"path/to/thing.ipynb language[python3]"
+        markup = "path/to/thing.ipynb language[python3]"
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
+        self.assertEqual(src, "path/to/thing.ipynb")
         self.assertIsNone(start)
         self.assertIsNone(end)
-        self.assertEqual(language, u"python3")
+        self.assertEqual(language, "python3")
 
     def test_notebook_tag_with_symbol_in_name_language(self):
-        for short_name in [u"c++", u"cpp-objdump", u"c++-objdumb", u"cxx-objdump"]:
-            markup = u"path/to/thing.ipynb language[{}]".format(short_name)
+        for short_name in ["c++", "cpp-objdump", "c++-objdumb", "cxx-objdump"]:
+            markup = f"path/to/thing.ipynb language[{short_name}]"
             src, start, end, language = self.get_argdict(markup)
 
-            self.assertEqual(src, u"path/to/thing.ipynb")
+            self.assertEqual(src, "path/to/thing.ipynb")
             self.assertIsNone(start)
             self.assertIsNone(end)
             self.assertEqual(language, short_name)
 
     def test_notebook_tag_with_language_and_cells(self):
-        markup = u"path/to/thing.ipynb cells[1:5] language[julia]"
+        markup = "path/to/thing.ipynb cells[1:5] language[julia]"
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
-        self.assertEqual(start, u"1")
-        self.assertEqual(end, u"5")
-        self.assertEqual(language, u"julia")
+        self.assertEqual(src, "path/to/thing.ipynb")
+        self.assertEqual(start, "1")
+        self.assertEqual(end, "5")
+        self.assertEqual(language, "julia")
 
     def test_notebook_tag_with_language_and_cells_and_weird_spaces(self):
-        markup = u"   path/to/thing.ipynb   cells[1:5]  language[julia]       "
+        markup = "   path/to/thing.ipynb   cells[1:5]  language[julia]       "
         src, start, end, language = self.get_argdict(markup)
 
-        self.assertEqual(src, u"path/to/thing.ipynb")
-        self.assertEqual(start, u"1")
-        self.assertEqual(end, u"5")
-        self.assertEqual(language, u"julia")
+        self.assertEqual(src, "path/to/thing.ipynb")
+        self.assertEqual(start, "1")
+        self.assertEqual(end, "5")
+        self.assertEqual(language, "julia")
 
 
 if __name__ == "__main__":

--- a/pelican/plugins/liquid_tags/video.py
+++ b/pelican/plugins/liquid_tags/video.py
@@ -68,12 +68,12 @@ def video(preprocessor, tag, markup):
         for vid in videos:
             base, ext = os.path.splitext(vid)
             if ext not in VID_TYPEDICT:
-                raise ValueError("Unrecognized video extension: " "{0}".format(ext))
-            video_out += "<source src='{0}' " "{1}>".format(vid, VID_TYPEDICT[ext])
+                raise ValueError("Unrecognized video extension: " "{}".format(ext))
+            video_out += "<source src='{}' " "{}>".format(vid, VID_TYPEDICT[ext])
         video_out += "</video></span>"
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     return video_out

--- a/pelican/plugins/liquid_tags/vimeo.py
+++ b/pelican/plugins/liquid_tags/vimeo.py
@@ -61,7 +61,7 @@ def vimeo(preprocessor, tag, markup):
         ).strip()
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     return vimeo_out

--- a/pelican/plugins/liquid_tags/youtube.py
+++ b/pelican/plugins/liquid_tags/youtube.py
@@ -100,7 +100,7 @@ def youtube(preprocessor, tag, markup):
             ).strip()
     else:
         raise ValueError(
-            "Error processing input, " "expected syntax: {0}".format(SYNTAX)
+            "Error processing input, " "expected syntax: {}".format(SYNTAX)
         )
 
     return youtube_out


### PR DESCRIPTION
Hi, in this PR I suggest to add the "loading" lazy/eager feature to the `img` tag.
This feature is now supported by most browsers and help to render responsive pages (cf. https://caniuse.com/loading-lazy-attr).

- I added a new setting for liquid-tags: `IMG_DEFAULT_LOADING` it can be `lazy` or `eager` (default);
=> I hope this will suit you ?
- Documentation is updated (Readme + module);
- The tests didn't cover the img module, so I did that by adding my new feature;
- I also fixed some typos and legacy python2.7 code

Thanks for reading.