### PR TITLE
Youtube tag fix settings

### DIFF
--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -24,6 +24,8 @@ LT_CONFIG = {
     "FLICKR_API_KEY": "flickr",
     "GIPHY_API_KEY": "giphy",
     "IMG_DEFAULT_LOADING": "eager",
+    "YOUTUBE_THUMB_ONLY": False,
+    "YOUTUBE_THUMB_SIZE": "",
 }
 LT_HELP = {
     "CODE_DIR": "Code directory for include_code subplugin",
@@ -31,6 +33,8 @@ LT_HELP = {
     "FLICKR_API_KEY": "Flickr key for accessing the API",
     "GIPHY_API_KEY": "Giphy key for accessing the API",
     "IMG_DEFAULT_LOADING": "The default loading method of images (eager or lazy)",
+    "YOUTUBE_THUMB_ONLY": "Embed a linked thumbnail instead 1MB of JS code",
+    "YOUTUBE_THUMB_SIZE": "Thumbnail dimensions maxres/sd (default)/hq/mq",
 }
 
 

--- a/pelican/plugins/liquid_tags/youtube.py
+++ b/pelican/plugins/liquid_tags/youtube.py
@@ -1,8 +1,29 @@
 """
 Youtube Tag
----------
+-----------
 This implements a Liquid-style youtube tag for Pelican,
 based on the jekyll / octopress youtube tag [1]_
+
+Configuration
+-------------
+
+- Embedding Thumbnail Only
+
+  If you do not want to add 1+ megabyte of JS code to your page, you can embed a
+  linked thumbnail instead. To do so, set a `YOUTUBE_THUMB_ONLY` variable in your
+  settings file. The `YOUTUBE_THUMB_SIZE` variable controls thumbnail dimensions,
+  with four sizes available:
+
+  ======  ======  ======
+  name    xres    yres
+  ======  ======  ======
+  maxres  1280    720
+  sd      640     480
+  hq      480     360
+  mq      320     180
+  ======  ======  ======
+
+  Embedded thumbnails have CSS class `youtube_video`, which can be used to add a Play button.
 
 Syntax
 ------

--- a/pelican/plugins/liquid_tags/youtube.py
+++ b/pelican/plugins/liquid_tags/youtube.py
@@ -97,7 +97,8 @@ def youtube(preprocessor, tag, markup):
             youtube_out = """<a
                     href="https://www.youtube.com/watch?v={youtube_id}"
                 class="youtube_video" alt="YouTube Video"
-                title="Click to view on YouTube">
+                title="Click to view on YouTube"
+                target="_blank" rel="noopener noreferrer">
                     <img width="{width}" height="{height}"
                         src="{thumb_url}/{size}default.jpg">
                 </a>""".format(


### PR DESCRIPTION
Hi, this PR should fix #15 and partially solve #7 (but yes there is a duplication of the documentation in the project :s).

- Settings are added in the "in-tree form";
- doc is updated
- I added the ability to open the link in the Youtube thumbnail mode into a new tab
`rel` tag attributes are added according to the vulnerability described [here](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#security_and_privacy).

Thanks for reading.