### PR TITLE
Markdown 3.4 compatibility

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.6.0
     hooks:
       - id: black
 

--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -93,14 +93,16 @@ class LiquidTags(markdown.Extension):
 
         return dec
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         self.htmlStash = md.htmlStash
         md.registerExtension(self)
         # for the include_code preprocessor, we need to re-run the
         # fenced code block preprocessor after substituting the code.
         # Because the fenced code processor is run before, {% %} tags
         # within equations will not be parsed as an include.
-        md.preprocessors.add("mdincludes", _LiquidTagsPreprocessor(self), ">html_block")
+        i = md.preprocessors.get_index_for_name("html_block")
+        priority = md.preprocessors._priority[i].priority - 5
+        md.preprocessors.register(_LiquidTagsPreprocessor(self), "mdincludes", priority)
 
 
 def makeExtension(configs=None):

--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -70,16 +70,9 @@ class LiquidTags(markdown.Extension):
     """Wrapper for MDPreprocessor"""
 
     def __init__(self, config):
-        try:
-            # Needed for markdown versions >= 2.5
-            for key, value in LT_CONFIG.items():
-                self.config[key] = [value, LT_HELP[key]]
-            super().__init__(**config)
-        except AttributeError:
-            # Markdown versions < 2.5
-            for key, value in LT_CONFIG.items():
-                config[key] = [config[key], LT_HELP[key]]
-            super().__init__(config)
+        for key, value in LT_CONFIG.items():
+            self.config[key] = [value, LT_HELP[key]]
+        super().__init__(**config)
 
     @classmethod
     def register(cls, tag):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ ipython = {version = ">=7.16.1"}
 nbconvert = ">=6.0.7"
 
 [tool.poetry.dev-dependencies]
-black = {version = "^21.5b1", allow-prereleases = true}
+black = "^22.6.0"
 flake8 = "^3.9"
 flake8-black = "^0.2"
 invoke = "^1.3"


### PR DESCRIPTION
Changes needed to fix #19 , which prevent plugin usage on fresh environment.

Also:

* remove Markdown 2.5 compatibility layer; that version dates back to 2014 and Pelican does not support it anymore, so why should we
* bump black dependency to avoid https://github.com/psf/black/issues/2964 , which wreaked havoc on CI systems back in early spring

Given that plugin is currently unusable in new installations, I think it does justify new release. I might try to cut it over the weekend, unless @justinmayer is first. 