### PR TITLE
add invidious as youtube frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 poetry.lock
+__pycache__

--- a/pelican/plugins/liquid_tags/mdx_liquid_tags.py
+++ b/pelican/plugins/liquid_tags/mdx_liquid_tags.py
@@ -26,6 +26,7 @@ LT_CONFIG = {
     "IMG_DEFAULT_LOADING": "eager",
     "YOUTUBE_THUMB_ONLY": False,
     "YOUTUBE_THUMB_SIZE": "",
+    "YOUTUBE_INVIDIOUS_INSTANCE": "",
 }
 LT_HELP = {
     "CODE_DIR": "Code directory for include_code subplugin",
@@ -35,6 +36,7 @@ LT_HELP = {
     "IMG_DEFAULT_LOADING": "The default loading method of images (eager or lazy)",
     "YOUTUBE_THUMB_ONLY": "Embed a linked thumbnail instead 1MB of JS code",
     "YOUTUBE_THUMB_SIZE": "Thumbnail dimensions maxres/sd (default)/hq/mq",
+    "YOUTUBE_INVIDIOUS_INSTANCE": "Alternative YouTube frontend",
 }
 
 

--- a/pelican/plugins/liquid_tags/test_youtube.py
+++ b/pelican/plugins/liquid_tags/test_youtube.py
@@ -31,7 +31,7 @@ class fake_proc:
 
 
 @pytest.mark.parametrize(
-    "input,expected",
+    "input,expected,thumb_only,invidious",
     [
         (
             "v78_WujMnVk",
@@ -43,14 +43,54 @@ class fake_proc:
                     <img width="1280" height="720"
                         src="https://img.youtube.com/vi/v78_WujMnVk/maxresdefault.jpg">
                 </a>""",
-        )
+            True,
+            "",
+        ),
+        (
+            "v78_WujMnVk",
+            """<span class="videobox">
+                    <iframe width="640" height="390"
+                        src='https://www.youtube.com/embed/v78_WujMnVk'
+                        frameborder='0' webkitAllowFullScreen
+                        mozallowfullscreen allowFullScreen>
+                    </iframe>
+                </span>""",
+            False,
+            "",
+        ),
+        (
+            "v78_WujMnVk",
+            """<a
+                    href="https://inv.example.com/watch?v=v78_WujMnVk"
+                class="youtube_video" alt="YouTube Video"
+                title="Click to view on YouTube"
+                target="_blank" rel="noopener noreferrer">
+                    <img width="1280" height="720"
+                        src="https://inv.example.com/vi/v78_WujMnVk/maxresdefault.jpg">
+                </a>""",
+            True,
+            "https://inv.example.com",
+        ),
+        (
+            "v78_WujMnVk",
+            """<span class="videobox">
+                    <iframe width="640" height="390"
+                        src='https://inv.example.com/embed/v78_WujMnVk'
+                        frameborder='0' webkitAllowFullScreen
+                        mozallowfullscreen allowFullScreen>
+                    </iframe>
+                </span>""",
+            False,
+            "https://inv.example.com",
+        ),
     ],
 )
-def test_youtube(input, expected):
+def test_youtube(input, expected, thumb_only, invidious):
     fake_preproc = fake_proc()
 
-    fake_preproc.configs.setConfig("YOUTUBE_THUMB_ONLY", True)
+    fake_preproc.configs.setConfig("YOUTUBE_THUMB_ONLY", thumb_only)
     fake_preproc.configs.setConfig("YOUTUBE_THUMB_SIZE", "maxres")
+    fake_preproc.configs.setConfig("YOUTUBE_INVIDIOUS_INSTANCE", invidious)
 
     print(fake_preproc.configs.config)
 


### PR DESCRIPTION
Invidious is an alternative frontend for youtube,
which can be used for privacy reasons.
by setting YOUTUBE_INVIDIOUS_INSTANCE to url of an instance, videos and thumbnails are embedded from there.