### PR TITLE
Update supported Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Sync supported Python versions in CI with main Pelican repo (drop 3.6, add 3.10 and 3.11).

This is also needed for us to continue using "ubuntu-latest" runner. Github is [changing ubuntu-latest to mean 22.04](https://github.com/actions/runner-images/issues/6399) - this will be finalized in March 2023, and right now some jobs are run on 22.04, while others are run on 20.04. However, there is no Python 3.6 on 22.04, so if we get unlucky, we will get failed run - [like in recent PR](https://github.com/pelican-plugins/liquid-tags/actions/runs/3586957036/jobs/6088562577).